### PR TITLE
Remove Google Analytics JS - Fixes #16

### DIFF
--- a/wiki/index.html
+++ b/wiki/index.html
@@ -68,15 +68,5 @@
         <p> </p>
       </section>
     </div>
-    <script type="text/javascript">
-            var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-            document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-          </script>
-    <script type="text/javascript">
-            try {
-              var pageTracker = _gat._getTracker("evil twin ");
-            pageTracker._trackPageview();
-            } catch(err) {}
-          </script>
   </body>
 </html>


### PR DESCRIPTION
Commit removes Google Analytics JS, because calls back home to mothership might
be unwanted.