### PR TITLE
Sort imports, replace and remove commands module which has been deprecated

### DIFF
--- a/infernal_wireless_gui_project.py
+++ b/infernal_wireless_gui_project.py
@@ -1114,8 +1114,6 @@ class wpa_cracker(wx.Frame):
 		print self.capturelist
 		print mySSID.GetValue()
 		
-		import subprocess
-		
 		#~ test = subprocess.Popen(["aircrack-ng","-w",self.wordlist,self.capturelist,"-l","captures/key_found.txt"], stdout=subprocess.PIPE)
 		
 		
@@ -1240,7 +1238,6 @@ class wpa2enterprise_cracker(wx.Frame):
 		
 		#~ os.system("gnome-terminal -x asleap -C "+self.g_challenge+" -R "+self.g_response+" -W "+self.wordlist+ " read")
 		print str(self.wordlist)
-		import subprocess
 		test = subprocess.Popen(["asleap","-C",str(self.g_challenge.GetValue()),"-R",str(self.g_response.GetValue()),"-W",str(self.filepath)], stdout=subprocess.PIPE)
 		output = test.communicate()[0]
 		

--- a/infernal_wireless_gui_project.py
+++ b/infernal_wireless_gui_project.py
@@ -1,28 +1,29 @@
-import wx
-import logging
-logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
-
 #from scapy.all import *
-import commands, re
-import wless_commands
-from scapy.all import *
+import InfernalWireless
+import access_to_db
+import commands
+import create_db_hotspot
+import fakePagecreate
+import httplib
+import logging
+import notepad
+import ntlm_hashes
 import os
+import re
+import redirecthandle
+import subprocess
 import time
 import traceback
-from subprocess import *
-from bs4 import BeautifulSoup
-from wp2_crack import *
-import create_db_hotspot
-import urllib2, httplib, redirecthandle
+import urllib2
+import wless_commands
+import wx
 import wx.html
-import notepad
-import InfernalWireless
-import fakePagecreate
-import ntlm_hashes
-import access_to_db
+from bs4 import BeautifulSoup
 from project_form import *
+from scapy.all import *
+from wp2_crack import *
 
-
+logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 
 class Example(wx.Frame):
 	

--- a/infernal_wireless_gui_project.py
+++ b/infernal_wireless_gui_project.py
@@ -447,9 +447,9 @@ sh /usr/local/etc/raddb/certs/bootstrap'''
 	
 	def mapWireless(self, e):
 		iface = wless_commands.get_monitoring_interfaces()[0]
-		os.system("ifconfig "+iface+" up")
+		wless_commands.bring_wlan_devs_up([iface])
 		#os.system("airmon-ng stop mon0")
-		os.system("airmon-ng start "+iface)
+		wless_commands.start_airmon([iface])
 		def ask(parent=None, message='', default_value=''):
 			
 			dlg = wx.TextEntryDialog(parent, message, defaultValue=default_value)
@@ -600,7 +600,7 @@ sh /usr/local/etc/raddb/certs/bootstrap'''
 	def free_evil(self, e):
 		iface = wless_commands.get_monitoring_interfaces()[0]
 		
-		os.system("ifconfig "+iface+" up")
+		wless_commands.bring_wlan_devs_up([iface])
 		proc = subprocess.Popen(["ifconfig", ""], stdout=subprocess.PIPE, shell=True)
 		(out, err) = proc.communicate()
 		
@@ -741,7 +741,7 @@ EOF"""%iface)
 	def probRequest(self, e):
 		iface = wless_commands.get_monitoring_interfaces()[0]
 		open('prob_request.txt', 'w').close()
-		os.system("ifconfig "+iface+" up")
+		wless_commands.bring_wlan_devs_up([iface])
 		#~ os.system("airmon-ng start wlan0")
 		
 		print 'airmon-ng start is created'
@@ -796,8 +796,7 @@ EOF"""%iface)
 		
 	def captureIV(self, e):
 		iface = wless_commands.get_monitoring_interfaces()[0]
-		
-		os.system("ifconfig "+iface+" up")
+		wless_commands.bring_wlan_devs_up([iface])
 		os.system("gnome-terminal -x airmon-ng start "+iface+" &")
 		#~ print 'mon0 is created'
 		time.sleep(5)	
@@ -825,8 +824,8 @@ EOF"""%iface)
 	
 	def fakeAPauth(self, e):
 		iface = wless_commands.get_monitoring_interfaces()[0]
-		os.system("ifconfig "+iface+" up")
-			
+		wless_commands.bring_wlan_devs_up([iface])
+
 		proc = subprocess.Popen(["ifconfig", ""], stdout=subprocess.PIPE, shell=True)
 		(out, err) = proc.communicate()
 		
@@ -1441,7 +1440,7 @@ class WPA2_crack(wx.Frame):
     def wireless_scan_cracker(self):
 		iface = wless_commands.get_monitoring_interfaces()[0]
 		
-		os.system("ifconfig "+iface+" up")
+		wless_commands.bring_wlan_devs_up([iface])
 		read_only_txt = wx.TextCtrl(self, -1, '', style=wx.TE_MULTILINE|wx.TE_READONLY, pos=(20, 200),size=(400,600))
 		proc1 = subprocess.Popen(['iw', iface, 'up'], stdout=subprocess.PIPE,
 				stderr=subprocess.PIPE)
@@ -1469,7 +1468,7 @@ class WPA2_crack(wx.Frame):
     def wpa_crack_key(self, SSID):
 		iface = wless_commands.get_monitoring_interfaces()[0]
 		
-		os.system("airmon-ng start "+iface)
+		wless_commands.start_airmon([iface])
 		#os.system("mkdir capture")
 		print 'wpa2 hack is started'
 		

--- a/infernal_wireless_gui_project.py
+++ b/infernal_wireless_gui_project.py
@@ -1,7 +1,6 @@
 #from scapy.all import *
 import InfernalWireless
 import access_to_db
-import commands
 import create_db_hotspot
 import fakePagecreate
 import httplib
@@ -1444,7 +1443,9 @@ class WPA2_crack(wx.Frame):
 		
 		os.system("ifconfig "+iface+" up")
 		read_only_txt = wx.TextCtrl(self, -1, '', style=wx.TE_MULTILINE|wx.TE_READONLY, pos=(20, 200),size=(400,600))
-		output = str(commands.getstatusoutput("iw "+iface+" scan")[1])
+		proc1 = subprocess.Popen(['iw', iface, 'up'], stdout=subprocess.PIPE,
+				stderr=subprocess.PIPE)
+		output, err = proc1.communicate()
 
 		#p = r'SSID: \S*|cipher: \S*|Authentication suites: \S*'
 		p = r'SSID: \S*|cipher: \S*'

--- a/infernal_wireless_gui_project.py
+++ b/infernal_wireless_gui_project.py
@@ -1,4 +1,3 @@
-#from scapy.all import *
 import InfernalWireless
 import access_to_db
 import create_db_hotspot

--- a/wless_commands.py
+++ b/wless_commands.py
@@ -54,9 +54,12 @@ def get_monitoring_interfaces():
 	return [dev for dev in sorted(get_net_devices())
 		if re.match(r'[wma]\S*', dev)]
 
-def start_airmon():
+def start_airmon(devices=[]):
 	"""Start airmon at all wlan interfaces."""
-	for dev in sorted(get_net_devices()):
+	if not devices:
+		devices = sorted(get_net_devices())
+
+	for dev in devices:
 		if re.match(r'^wlan[0-9]$', dev):
 			os.system("airmon-ng start %s" % dev)
 

--- a/wless_commands.py
+++ b/wless_commands.py
@@ -1,4 +1,5 @@
 from scapy.all import *
+import logging
 import multiprocessing
 import re
 import subprocess


### PR DESCRIPTION
Changes:
* sort imports A-Z and replace 
* remove commands module which has been deprecated since Py 2.6 and removed in Py 3.x.
* remove interface checks via % ifconfig; call
* fix missing import of logging module
* replace os.system() calls with function calls